### PR TITLE
Update zsh to a later version

### DIFF
--- a/ansible/roles/server/tasks/packages.yml
+++ b/ansible/roles/server/tasks/packages.yml
@@ -8,6 +8,12 @@
     enablerepo=epel
   with_items: "{{ packages_standard }}"
 
+- name: zsh | Update to base zsh installation
+  yum:
+    name: http://mirror.ghettoforge.org/distributions/gf/el/6/plus/x86_64//zsh-5.0.7-5.gf.el6.x86_64.rpm
+    state: present
+    allow_downgrade: no
+
 - name: YUM | Install the remi-release rpm
   yum:
     name=http://rpms.famillecollet.com/enterprise/remi-release-7.rpm


### PR DESCRIPTION
The default version of zsh on centos is older and doesn't support the
dotfiles that are currently installed in this base image. This commit
upgrades the installed version of zsh to the minimum version required to
support those dotfiles.