### PR TITLE
Fix PHP-FPM Start Command

### DIFF
--- a/ansible/roles/server/templates/etc/supervisord.conf
+++ b/ansible/roles/server/templates/etc/supervisord.conf
@@ -49,7 +49,7 @@ serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 ;history_file=~/.sc_history  ; use readline history if available
 
 [program:php-fpm]
-command=/usr/sbin/php-fpm5.5 -c /etc/php/5.5/fpm/php-fpm.conf
+command=/usr/sbin/php-fpm5.5 -c /etc/php/5.5/fpm/
 autostart=true
 autorestart=true
 priority=5


### PR DESCRIPTION
Summary:
The PHP-FPM command is being started with a defined directory to search for an .ini file.
However, we aren't providing a directory -- we are pathing to a specific file. This prevents
the process from locating the appropriate php.ini file.